### PR TITLE
fix optimizer name and number of iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The ICOR model was trained in the MATLAB environment. For more details on model 
 > A document that contains all of the benchmarking genes and descriptions of them.
 
 #### Optimizers
-`BFC_optimizer.py`
-> Background Frequency Choice optimizer creates a directory containing amino acid sequences in the FASTA format and saves these "optimized" / "generated" DNA sequences in a directory. It generates 10,000 sequences using the URC algorithm and chooses the one with the highest CAI.
+`ERC_optimizer.py`
+> Background Frequency Choice optimizer creates a directory containing amino acid sequences in the FASTA format and saves these "optimized" / "generated" DNA sequences in a directory. It generates 100,000 sequences using the URC algorithm and chooses the one with the highest CAI.
 
 `icor_optimizer.py`
 > ICOR optimizer outputs a text file given a sequence input of amino acids or DNA. It is an interactive Python command-line script. It runs an inference through the ICOR model.


### PR DESCRIPTION
`BFC_optimizer.py` appears two times in the optimizer list. One of them seems to be the ERC optimizer. I was looking at the code of the ERC optimizer and the algorithm seems to actually iterate 100.000 times, instead of just 10.000. https://github.com/Lattice-Automation/icor-codon-optimization/blob/2ed3edc3ba7d67f19ad0d4a14df3d9db25b8ac74/tool/optimizers/ERC_optimizer.py#L138